### PR TITLE
Reduce package size

### DIFF
--- a/build_libzmq.sh
+++ b/build_libzmq.sh
@@ -23,5 +23,5 @@ cd $ZMQ_SRC_DIR
 
 test -f configure || ./autogen.sh
 ./configure --prefix=$ZMQ_PREFIX --with-relaxed --enable-static --disable-shared
-V=1 make -j
+make -j 2
 make install

--- a/build_libzmq.sh
+++ b/build_libzmq.sh
@@ -25,3 +25,6 @@ test -f configure || ./autogen.sh
 ./configure --prefix=$ZMQ_PREFIX --with-relaxed --enable-static --disable-shared
 make -j 2
 make install
+
+cd $ZMQ_PREFIX
+rm -rf $ZMQ_SRC_DIR


### PR DESCRIPTION
This PR introduces two changes:
- Build libzmq with 2 cores only: I timed it [here](https://github.com/n-riesco/jp-kernel/pull/3#issuecomment-257561385) and it doesn't make sense to use more on a average machine.
- Remove libzmq source after build: This will reduce the package size by about 16.5 MB. I'm leaving the `.tar.gz` file so it doesn't have to be downloaded again on rebuilding (795KB).

 /cc @rgbkrk @n-riesco