### PR TITLE
Unix: Bump libzmq@4.1.6

### DIFF
--- a/build_libzmq.sh
+++ b/build_libzmq.sh
@@ -3,7 +3,7 @@ set -e
 
 test -d zmq || mkdir zmq
 
-ZMQ=4.1.5
+ZMQ=4.1.6
 ZMQ_REPO=zeromq/zeromq4-1
 
 realpath() {


### PR DESCRIPTION
I'll upgrade the windows libs on the bump to 4.2.0