### PR TITLE
Use prebuild preinstall script for building libzmq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ deploy:
   skip_cleanup: true
   # Linking to prebuild directly since it doesn't work inside a npm script.
   script:
-    - node_modules/prebuild/bin.js --all -u $GH_TOKEN
+    - node_modules/prebuild/bin.js --all --strip -u $GH_TOKEN
   on:
     condition: "$DEPLOY = true"
     tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ test_script:
   - IF DEFINED ELECTRON (appveyor-retry call npm run test:electron) ELSE (appveyor-retry call npm test)
 
 deploy_script:
-  - IF "%deploy%;%appveyor_repo_tag%"=="true;true" (node_modules\.bin\prebuild --all -u %GITHUB_TOKEN%)
+  - IF "%deploy%;%appveyor_repo_tag%"=="true;true" (node_modules\.bin\prebuild --all --strip -u %GITHUB_TOKEN%)
 
 notifications:
   - provider: Slack

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,6 @@
       'cflags_cc!': ['-fno-exceptions'],
       'conditions': [
         ['OS=="win"', {
-          'download_lib': '<!(node scripts/download-win-lib 2>&1 > zmq-build.log)',
           'msbuild_toolset': 'v140',
           'defines': ['ZMQ_STATIC'],
           'include_dirs': ['windows/include'],
@@ -18,7 +17,6 @@
           ],
         }],
         ['OS=="mac" or OS=="solaris"', {
-          'install_zmq': '<!(./build_libzmq.sh 2>&1 > zmq-build.log)',
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
             'MACOSX_DEPLOYMENT_TARGET': '10.7',
@@ -29,7 +27,6 @@
         ['OS=="openbsd" or OS=="freebsd"', {
         }],
         ['OS=="linux"', {
-          'install_zmq': '<!(./build_libzmq.sh 2>&1 > zmq-build.log)',
           'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
           'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],
         }],

--- a/build_libzmq.sh
+++ b/build_libzmq.sh
@@ -17,7 +17,7 @@ export CFLAGS=-fPIC
 export CXXFLAGS=-fPIC
 export PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig
 
-test -f zeromq-$ZMQ.tar.gz || ZMQ=$ZMQ ZMQ_REPO=$ZMQ_REPO node ../scripts/download-zmq.js 2>&1 > ../zmq-build.log
+test -f zeromq-$ZMQ.tar.gz || ZMQ=$ZMQ ZMQ_REPO=$ZMQ_REPO node ../scripts/download-zmq.js
 test -d $ZMQ_SRC_DIR || tar xzf zeromq-$ZMQ.tar.gz
 cd $ZMQ_SRC_DIR
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=0.10"
   },
   "scripts": {
-    "build:libzmq": "node scripts/download-win-lib.js && ./build_libzmq.sh",
+    "build:libzmq": "node scripts/preinstall.js",
     "install": "prebuild --install --preinstall \"npm run build:libzmq\"",
     "rebuild": "prebuild --compile",
     "prebuild": "prebuild --all --strip",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build:libzmq": "node scripts/download-win-lib.js && ./build_libzmq.sh",
     "install": "prebuild --install --preinstall \"npm run build:libzmq\"",
+    "rebuild": "prebuild --compile",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
     "test": "mocha --expose-gc --slow 300",
     "test:electron": "electron-mocha --slow 300",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:libzmq": "node scripts/download-win-lib.js && ./build_libzmq.sh",
     "install": "prebuild --install --preinstall \"npm run build:libzmq\"",
     "rebuild": "prebuild --compile",
+    "prebuild": "prebuild --all --strip",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
     "test": "mocha --expose-gc --slow 300",
     "test:electron": "electron-mocha --slow 300",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node": ">=0.10"
   },
   "scripts": {
-    "install": "prebuild --install",
+    "build:libzmq": "node scripts/download-win-lib.js && ./build_libzmq.sh",
+    "install": "prebuild --install --preinstall \"npm run build:libzmq\"",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
     "test": "mocha --expose-gc --slow 300",
     "test:electron": "electron-mocha --slow 300",

--- a/scripts/build_libzmq.sh
+++ b/scripts/build_libzmq.sh
@@ -9,7 +9,8 @@ ZMQ_REPO=zeromq/zeromq4-1
 realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
-export ZMQ_PREFIX="$(dirname $(realpath $0))/zmq"
+export MAIN_DIR="$(dirname $(realpath $0))/../"
+export ZMQ_PREFIX=$MAIN_DIR/zmq
 export ZMQ_SRC_DIR=zeromq-$ZMQ
 cd $ZMQ_PREFIX
 
@@ -17,7 +18,7 @@ export CFLAGS=-fPIC
 export CXXFLAGS=-fPIC
 export PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig
 
-test -f zeromq-$ZMQ.tar.gz || ZMQ=$ZMQ ZMQ_REPO=$ZMQ_REPO node ../scripts/download-zmq.js
+test -f zeromq-$ZMQ.tar.gz || ZMQ=$ZMQ ZMQ_REPO=$ZMQ_REPO node $MAIN_DIR/scripts/download-zmq.js
 test -d $ZMQ_SRC_DIR || tar xzf zeromq-$ZMQ.tar.gz
 cd $ZMQ_SRC_DIR
 

--- a/scripts/download-win-lib.js
+++ b/scripts/download-win-lib.js
@@ -1,13 +1,16 @@
-var download = require('./download').download;
-var path = require('path');
-var fs = require('fs');
+if (process.platform === 'win32') {
+  console.log('Downloading libzmq for Windows')
+  var download = require('./download').download;
+  var path = require('path');
+  var fs = require('fs');
 
-var TAR_URL = 'https://github.com/nteract/libzmq-win/releases/download/v1.0.0/libzmq-' + process.arch + '.lib';
-var DIR_NAME = path.join(__dirname, '..', 'windows', 'lib');
-var FILE_NAME = path.join(DIR_NAME, 'libzmq.lib');
+  var TAR_URL = 'https://github.com/nteract/libzmq-win/releases/download/v1.0.0/libzmq-' + process.arch + '.lib';
+  var DIR_NAME = path.join(__dirname, '..', 'windows', 'lib');
+  var FILE_NAME = path.join(DIR_NAME, 'libzmq.lib');
 
-if (!fs.existsSync(DIR_NAME)) {
-  fs.mkdirSync(DIR_NAME);
+  if (!fs.existsSync(DIR_NAME)) {
+    fs.mkdirSync(DIR_NAME);
+  }
+
+  download(TAR_URL, FILE_NAME);
 }
-
-download(TAR_URL, FILE_NAME);

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -23,6 +23,6 @@ if (process.platform === 'win32') {
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stderr);
   child.on('error', (err) => {
-    console.log('Failed to start child process.');
+    console.error('Failed to start child process.');
   });
 }

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,8 +1,10 @@
+var download = require('./download').download;
+var spawn = require('child_process').spawn;
+var path = require('path');
+var fs = require('fs');
+
 if (process.platform === 'win32') {
   console.log('Downloading libzmq for Windows')
-  var download = require('./download').download;
-  var path = require('path');
-  var fs = require('fs');
 
   var TAR_URL = 'https://github.com/nteract/libzmq-win/releases/download/v1.0.0/libzmq-' + process.arch + '.lib';
   var DIR_NAME = path.join(__dirname, '..', 'windows', 'lib');
@@ -16,12 +18,11 @@ if (process.platform === 'win32') {
 } else {
   console.log('Building libzmq for ' + process.platform)
 
-  var spawn = require('child_process').spawn;
-  var child = spawn('./build_libzmq.sh');
+  var child = spawn('./scripts/build_libzmq.sh');
 
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stderr);
   child.on('error', (err) => {
-  console.log('Failed to start child process.');
-});
+    console.log('Failed to start child process.');
+  });
 }

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -13,4 +13,15 @@ if (process.platform === 'win32') {
   }
 
   download(TAR_URL, FILE_NAME);
+} else {
+  console.log('Building libzmq for ' + process.platform)
+
+  var spawn = require('child_process').spawn;
+  var child = spawn('./build_libzmq.sh');
+
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  child.on('error', (err) => {
+  console.log('Failed to start child process.');
+});
 }


### PR DESCRIPTION
General improvements to the install scripts:
- Use prebuild preinstall script to improve error logging. We don't need to trigger the buildscripts inside the gyp file anymore.
- Add rebuild script.
- Strip debug information from binaries to reduce their size.