### PR TITLE
Fix Nan type missmatch warnings

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -655,7 +655,7 @@ namespace zmq {
       return Nan::ThrowError("Must pass an option");
     if (!info[0]->IsNumber())
       return Nan::ThrowTypeError("Option must be an integer");
-    int64_t option = Nan::To<int64_t>(info[0]).FromJust();
+    int option = Nan::To<int>(info[0]).FromJust();
 
     GET_SOCKET(info);
 
@@ -679,7 +679,7 @@ namespace zmq {
       return Nan::ThrowError("Must pass an option and a value");
     if (!info[0]->IsNumber())
       return Nan::ThrowTypeError("Option must be an integer");
-    int64_t option = Nan::To<int64_t>(info[0]).FromJust();
+    int option = Nan::To<int>(info[0]).FromJust();
     GET_SOCKET(info);
 
     if (opts_int.count(option)) {

--- a/binding.cc
+++ b/binding.cc
@@ -1082,7 +1082,7 @@ namespace zmq {
     int flags = 0;
     int64_t more = 1;
     size_t more_size = sizeof(more);
-    size_t index = 0;
+    uint32_t index = 0;
 
     Local<Array> result = Nan::New<Array>();
 
@@ -1252,7 +1252,7 @@ namespace zmq {
     if (len % 2 != 0)
       return Nan::ThrowTypeError("Batch length must be even!");
 
-    for (size_t i = 0; i < len; i += 2) {
+    for (uint32_t i = 0; i < len; i += 2) {
       if (checkPollOut) {
         while (zmq_getsockopt(socket->socket_, ZMQ_EVENTS, &events, &events_size)) {
           if (zmq_errno() != EINTR)


### PR DESCRIPTION
I wrestled down some windows build warnings 😄 

The only warning I don't know how to fix is thrown [here](https://github.com/zeromq/zeromq.js/blob/master/binding.cc#L613):
```
c:\projects\zmq-prebuilt\node_modules\nan\nan_new.h(208): warning C4244: 'argument': conversion from 'int64_t' to 'double', possible loss of data (compiling source file ..\binding.cc) [C:\projects\zmq-prebuilt\build\zmq.vcxproj]
  ..\binding.cc(613): note: see reference to function template instantiation 'v8::Local<v8::Number> Nan::New<v8::Number,T>(A0)' being compiled
          with
          [
              T=int64_t,
              A0=int64_t
          ]
  ..\binding.cc(667): note: see reference to function template instantiation 'v8::Local<v8::Value> zmq::Socket::GetSockOpt<int64_t>(int)' being compiled
c:\projects\zmq-prebuilt\node_modules\nan\nan_new.h(208): warning C4244: 'argument': conversion from 'uint64_t' to 'double', possible loss of data (compiling source file ..\binding.cc) [C:\projects\zmq-prebuilt\build\zmq.vcxproj]
  ..\binding.cc(613): note: see reference to function template instantiation 'v8::Local<v8::Number> Nan::New<v8::Number,T>(A0)' being compiled
          with
          [
              T=uint64_t,
              A0=uint64_t
          ]
  ..\binding.cc(669): note: see reference to function template instantiation 'v8::Local<v8::Value> zmq::Socket::GetSockOpt<uint64_t>(int)' being compiled
     Creating library C:\projects\zmq-prebuilt\build\Release\zmq.lib and object C:\projects\zmq-prebuilt\build\Release\zmq.exp
```