### PR TITLE
Upgrade libzmq 4.2.0

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -26,7 +26,9 @@
 #include <node_version.h>
 #include <node_buffer.h>
 #include <zmq.h>
+#if (ZMQ_VERSION < 40200)
 #include <zmq_utils.h>
+#endif
 #include <assert.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/binding.gyp
+++ b/binding.gyp
@@ -14,6 +14,7 @@
           'libraries': [
             '<(PRODUCT_DIR)/../../windows/lib/libzmq',
             'ws2_32.lib',
+            'iphlpapi'
           ],
         }],
         ['OS=="mac" or OS=="solaris"', {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
-comment:
-    layout: header
+comment: false
 coverage:
     status:
         patch:

--- a/scripts/build_libzmq.sh
+++ b/scripts/build_libzmq.sh
@@ -1,16 +1,14 @@
 #!/bin/sh
 set -e
 
-test -d zmq || mkdir zmq
+if [ "$1" != "" ]; then
+  ZMQ=$1
+else
+  echo "No ZMQ version given"
+  exit 1
+fi
 
-ZMQ=4.2.0
-ZMQ_REPO=zeromq/libzmq
-
-realpath() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-export MAIN_DIR="$(dirname $(realpath $0))/../"
-export ZMQ_PREFIX=$MAIN_DIR/zmq
+export ZMQ_PREFIX="$(dirname $0)/../zmq"
 export ZMQ_SRC_DIR=zeromq-$ZMQ
 cd $ZMQ_PREFIX
 
@@ -18,7 +16,6 @@ export CFLAGS=-fPIC
 export CXXFLAGS=-fPIC
 export PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig
 
-test -f zeromq-$ZMQ.tar.gz || ZMQ=$ZMQ ZMQ_REPO=$ZMQ_REPO node $MAIN_DIR/scripts/download-zmq.js
 test -d $ZMQ_SRC_DIR || tar xzf zeromq-$ZMQ.tar.gz
 cd $ZMQ_SRC_DIR
 

--- a/scripts/build_libzmq.sh
+++ b/scripts/build_libzmq.sh
@@ -3,8 +3,8 @@ set -e
 
 test -d zmq || mkdir zmq
 
-ZMQ=4.1.6
-ZMQ_REPO=zeromq/zeromq4-1
+ZMQ=4.2.0
+ZMQ_REPO=zeromq/libzmq
 
 realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"

--- a/scripts/download-zmq.js
+++ b/scripts/download-zmq.js
@@ -1,6 +1,0 @@
-var download = require('./download').download;
-
-var TAR_URL = 'https://github.com/' + process.env.ZMQ_REPO + '/releases/download/v' + process.env.ZMQ + '/zeromq-' + process.env.ZMQ + '.tar.gz';
-var FILE_NAME = 'zeromq-' + process.env.ZMQ + '.tar.gz';
-
-download(TAR_URL, FILE_NAME);

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -2,24 +2,25 @@ var https = require('https');
 var fs = require('fs');
 var url = require('url');
 
-function writeToFile(filename, response) {
+function writeToFile(filename, response, callback) {
   response.pipe(fs.createWriteStream(filename));
+  response.on('end', callback)
 }
 
-function download(fileUrl, filename) {
+function download(fileUrl, filename, callback) {
   https.get(fileUrl, function(response) {
     if (response.statusCode > 300 && response.statusCode < 400 && response.headers.location) {
       if (url.parse(response.headers.location).hostname) {
         https.get(response.headers.location, function(res) {
-          writeToFile(filename, res);
+          writeToFile(filename, res, callback);
         });
       } else {
         https.get(url.resolve(url.parse(fileUrl).hostname, response.headers.location), function(res) {
-          writeToFile(filename, res);
+          writeToFile(filename, res, callback);
         });
       }
     } else {
-      writeToFile(filename, response);
+      writeToFile(filename, response, callback);
     }
   });
 }

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -3,10 +3,22 @@ var spawn = require('child_process').spawn;
 var path = require('path');
 var fs = require('fs');
 
-if (process.platform === 'win32') {
-  console.log('Downloading libzmq for Windows')
+var ZMQ = '4.2.0';
 
-  var TAR_URL = 'https://github.com/nteract/libzmq-win/releases/download/v1.0.0/libzmq-' + process.arch + '.lib';
+function buildZMQ(scriptPath) {
+  console.log('Building libzmq for ' + process.platform)
+
+  var child = spawn(scriptPath, [ZMQ]);
+
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  child.on('error', (err) => {
+    console.error('Failed to start child process.');
+  });
+}
+
+if (process.platform === 'win32') {
+  var LIB_URL = 'https://github.com/nteract/libzmq-win/releases/download/v2.0.0/libzmq-' + ZMQ + '-' + process.arch + '.lib';
   var DIR_NAME = path.join(__dirname, '..', 'windows', 'lib');
   var FILE_NAME = path.join(DIR_NAME, 'libzmq.lib');
 
@@ -14,15 +26,26 @@ if (process.platform === 'win32') {
     fs.mkdirSync(DIR_NAME);
   }
 
-  download(TAR_URL, FILE_NAME);
+  if (!fs.existsSync(FILE_NAME)) {
+    console.log('Downloading libzmq for Windows');
+    download(LIB_URL, FILE_NAME, function() {
+      console.log('Download finished');
+    });
+  }
+
 } else {
-  console.log('Building libzmq for ' + process.platform)
+  var SCRIPT_PATH = path.join(__dirname, 'build_libzmq.sh');
+  var TAR_URL = 'https://github.com/zeromq/libzmq/releases/download/v' + ZMQ + '/zeromq-' + ZMQ + '.tar.gz';
+  var DIR = path.join(__dirname, '..', 'zmq');
+  var FILE_NAME = path.join(DIR, 'zeromq-' + ZMQ + '.tar.gz');
 
-  var child = spawn('./scripts/build_libzmq.sh');
+  if (!fs.existsSync(DIR)) {
+    fs.mkdirSync(DIR);
+  }
 
-  child.stdout.pipe(process.stdout);
-  child.stderr.pipe(process.stderr);
-  child.on('error', (err) => {
-    console.error('Failed to start child process.');
-  });
+  if (fs.existsSync(FILE_NAME)) {
+    buildZMQ(SCRIPT_PATH);
+  } else {
+    download(TAR_URL, FILE_NAME, function() { buildZMQ(SCRIPT_PATH); });
+  }
 }

--- a/test/socket.router.js
+++ b/test/socket.router.js
@@ -21,10 +21,11 @@ describe('socket.router', function(){
     var errMsgs = require('os').platform() === 'win32' ? ['Unknown error'] : [];
     errMsgs.push('No route to host');
     errMsgs.push('Resource temporarily unavailable');
+    errMsgs.push('Host unreachable');
 
     function assertRouteError(err) {
       if (errMsgs.indexOf(err.message) === -1) {
-        throw new Error('Bad error');
+        throw new Error(err.message);
       }
     }
 

--- a/windows/include/zmq.h
+++ b/windows/include/zmq.h
@@ -1,25 +1,35 @@
 /*
-    Copyright (c) 2007-2015 Contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2016 Contributors as noted in the AUTHORS file
 
-    This file is part of 0MQ.
+    This file is part of libzmq, the ZeroMQ core engine in C++.
 
-    0MQ is free software; you can redistribute it and/or modify it under
-    the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
     (at your option) any later version.
 
-    0MQ is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
 
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     *************************************************************************
     NOTE to contributors. This file comprises the principal public contract
-    for ZeroMQ API users (along with zmq_utils.h). Any change to this file
-    supplied in a stable release SHOULD not break existing applications.
+    for ZeroMQ API users. Any change to this file supplied in a stable
+    release SHOULD not break existing applications.
     In practice this means that the value of constants must not change, and
     that old values may not be reused for new constants.
     *************************************************************************
@@ -30,8 +40,8 @@
 
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
-#define ZMQ_VERSION_MINOR 1
-#define ZMQ_VERSION_PATCH 5
+#define ZMQ_VERSION_MINOR 2
+#define ZMQ_VERSION_PATCH 0
 
 #define ZMQ_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))
@@ -48,6 +58,20 @@ extern "C" {
 #include <stddef.h>
 #include <stdio.h>
 #if defined _WIN32
+//  Set target version to Windows Server 2008, Windows Vista or higher.
+//  Windows XP (0x0501) is supported but without client & server socket types.
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
+#ifdef __MINGW32__
+//  Require Windows XP or higher with MinGW for getaddrinfo().
+#if(_WIN32_WINNT >= 0x0600)
+#else
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+#endif
 #include <winsock2.h>
 #endif
 
@@ -175,13 +199,13 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 /*  0MQ infrastructure (a.k.a. context) initialisation & termination.         */
 /******************************************************************************/
 
-/*  New API                                                                   */
 /*  Context options                                                           */
 #define ZMQ_IO_THREADS  1
 #define ZMQ_MAX_SOCKETS 2
 #define ZMQ_SOCKET_LIMIT 3
 #define ZMQ_THREAD_PRIORITY 3
 #define ZMQ_THREAD_SCHED_POLICY 4
+#define ZMQ_MAX_MSGSZ 5
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT  1
@@ -191,7 +215,7 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 
 ZMQ_EXPORT void *zmq_ctx_new (void);
 ZMQ_EXPORT int zmq_ctx_term (void *context);
-ZMQ_EXPORT int zmq_ctx_shutdown (void *ctx_);
+ZMQ_EXPORT int zmq_ctx_shutdown (void *context);
 ZMQ_EXPORT int zmq_ctx_set (void *context, int option, int optval);
 ZMQ_EXPORT int zmq_ctx_get (void *context, int option);
 
@@ -205,7 +229,23 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-typedef struct zmq_msg_t {unsigned char _ [64];} zmq_msg_t;
+/* Some architectures, like sparc64 and some variants of aarch64, enforce pointer
+ * alignment and raise sigbus on violations. Make sure applications allocate
+ * zmq_msg_t on addresses aligned on a pointer-size boundary to avoid this issue.
+ */
+typedef struct zmq_msg_t {
+#if defined (__GNUC__) || defined ( __INTEL_COMPILER) || \
+        (defined (__SUNPRO_C) && __SUNPRO_C >= 0x590) || \
+        (defined (__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+    unsigned char _ [64] __attribute__ ((aligned (sizeof (void *))));
+#elif defined (_MSC_VER) && (defined (_M_X64) || defined (_M_ARM64))
+    __declspec (align (8)) unsigned char _ [64];
+#elif defined (_MSC_VER) && (defined (_M_IX86) || defined (_M_ARM_ARMV7VE))
+    __declspec (align (4)) unsigned char _ [64];
+#else
+    unsigned char _ [64];
+#endif
+} zmq_msg_t;
 
 typedef void (zmq_free_fn) (void *data, void *hint);
 
@@ -224,7 +264,6 @@ ZMQ_EXPORT int zmq_msg_more (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_get (zmq_msg_t *msg, int property);
 ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int property, int optval);
 ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
-
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */
@@ -304,10 +343,29 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_HANDSHAKE_IVL 66
 #define ZMQ_SOCKS_PROXY 68
 #define ZMQ_XPUB_NODROP 69
+#define ZMQ_BLOCKY 70
+#define ZMQ_XPUB_MANUAL 71
+#define ZMQ_XPUB_WELCOME_MSG 72
+#define ZMQ_STREAM_NOTIFY 73
+#define ZMQ_INVERT_MATCHING 74
+#define ZMQ_HEARTBEAT_IVL 75
+#define ZMQ_HEARTBEAT_TTL 76
+#define ZMQ_HEARTBEAT_TIMEOUT 77
+#define ZMQ_XPUB_VERBOSER 78
+#define ZMQ_CONNECT_TIMEOUT 79
+#define ZMQ_TCP_MAXRT 80
+#define ZMQ_THREAD_SAFE 81
+#define ZMQ_MULTICAST_MAXTPDU 84
+#define ZMQ_VMCI_BUFFER_SIZE 85
+#define ZMQ_VMCI_BUFFER_MIN_SIZE 86
+#define ZMQ_VMCI_BUFFER_MAX_SIZE 87
+#define ZMQ_VMCI_CONNECT_TIMEOUT 88
+#define ZMQ_USE_FD 89
+//  All options after this is for version 4.3 and still *draft*
+//  Subject to arbitrary change without notice
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
-#define ZMQ_SRCFD 2
 #define ZMQ_SHARED 3
 
 /*  Send/recv options.                                                        */
@@ -320,6 +378,9 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_CURVE 2
 #define ZMQ_GSSAPI 3
 
+/*  RADIO-DISH protocol                                                       */
+#define ZMQ_GROUP_MAX_LENGTH        15
+
 /*  Deprecated options and aliases                                            */
 #define ZMQ_TCP_ACCEPT_FILTER       38
 #define ZMQ_IPC_FILTER_PID          58
@@ -331,11 +392,14 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_FAIL_UNROUTABLE         ZMQ_ROUTER_MANDATORY
 #define ZMQ_ROUTER_BEHAVIOR         ZMQ_ROUTER_MANDATORY
 
+/*  Deprecated Message options                                                */
+#define ZMQ_SRCFD 2
+
 /******************************************************************************/
 /*  0MQ socket events and monitoring                                          */
 /******************************************************************************/
 
-/*  Socket transport events (TCP and IPC only)                                */
+/*  Socket transport events (TCP, IPC and TIPC only)                          */
 
 #define ZMQ_EVENT_CONNECTED         0x0001
 #define ZMQ_EVENT_CONNECT_DELAYED   0x0002
@@ -373,6 +437,7 @@ ZMQ_EXPORT int zmq_socket_monitor (void *s, const char *addr, int events);
 #define ZMQ_POLLIN 1
 #define ZMQ_POLLOUT 2
 #define ZMQ_POLLERR 4
+#define ZMQ_POLLPRI 8
 
 typedef struct zmq_pollitem_t
 {
@@ -388,7 +453,7 @@ typedef struct zmq_pollitem_t
 
 #define ZMQ_POLLITEMS_DFLT 16
 
-ZMQ_EXPORT int zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
+ZMQ_EXPORT int  zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
 
 /******************************************************************************/
 /*  Message proxying                                                          */
@@ -413,7 +478,9 @@ ZMQ_EXPORT int zmq_has (const char *capability);
 ZMQ_EXPORT int zmq_device (int type, void *frontend, void *backend);
 ZMQ_EXPORT int zmq_sendmsg (void *s, zmq_msg_t *msg, int flags);
 ZMQ_EXPORT int zmq_recvmsg (void *s, zmq_msg_t *msg, int flags);
-
+struct iovec;
+ZMQ_EXPORT int zmq_sendiov (void *s, struct iovec *iov, size_t count, int flags);
+ZMQ_EXPORT int zmq_recviov (void *s, struct iovec *iov, size_t *count, int flags);
 
 /******************************************************************************/
 /*  Encryption functions                                                      */
@@ -425,9 +492,24 @@ ZMQ_EXPORT char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size);
 /*  Decode data with Z85 encoding. Returns decoded data                       */
 ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest, const char *string);
 
-/*  Generate z85-encoded public and private keypair with libsodium.           */
+/*  Generate z85-encoded public and private keypair with tweetnacl/libsodium. */
 /*  Returns 0 on success.                                                     */
 ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);
+
+/*  Derive the z85-encoded public key from the z85-encoded secret key.        */
+/*  Returns 0 on success.                                                     */
+ZMQ_EXPORT int zmq_curve_public (char *z85_public_key, const char *z85_secret_key);
+
+/******************************************************************************/
+/*  Atomic utility methods                                                    */
+/******************************************************************************/
+
+ZMQ_EXPORT void *zmq_atomic_counter_new (void);
+ZMQ_EXPORT void zmq_atomic_counter_set (void *counter, int value);
+ZMQ_EXPORT int zmq_atomic_counter_inc (void *counter);
+ZMQ_EXPORT int zmq_atomic_counter_dec (void *counter);
+ZMQ_EXPORT int zmq_atomic_counter_value (void *counter);
+ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p);
 
 
 /******************************************************************************/
@@ -435,11 +517,6 @@ ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);
 /*  If you need these to be part of the formal ZMQ API, then (a) write a man  */
 /*  page, and (b) write a test case in tests.                                 */
 /******************************************************************************/
-
-struct iovec;
-
-ZMQ_EXPORT int zmq_sendiov (void *s, struct iovec *iov, size_t count, int flags);
-ZMQ_EXPORT int zmq_recviov (void *s, struct iovec *iov, size_t *count, int flags);
 
 /*  Helper functions are used by perf tests so that they don't have to care   */
 /*  about minutiae of time-related functions on different OS platforms.       */
@@ -463,6 +540,88 @@ ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn* func, void* arg);
 ZMQ_EXPORT void zmq_threadclose (void* thread);
 
 
+/******************************************************************************/
+/*  These functions are DRAFT and disabled in stable releases, and subject to */
+/*  change at ANY time until declared stable.                                 */
+/******************************************************************************/
+
+#ifdef ZMQ_BUILD_DRAFT_API
+
+/*  DRAFT Socket types.                                                       */
+#define ZMQ_SERVER 12
+#define ZMQ_CLIENT 13
+#define ZMQ_RADIO 14
+#define ZMQ_DISH 15
+#define ZMQ_GATHER 16
+#define ZMQ_SCATTER 17
+#define ZMQ_DGRAM 18
+
+/*  DRAFT Socket methods.                                                     */
+ZMQ_EXPORT int zmq_join (void *s, const char *group);
+ZMQ_EXPORT int zmq_leave (void *s, const char *group);
+
+/*  DRAFT Msg methods.                                                        */
+ZMQ_EXPORT int zmq_msg_set_routing_id(zmq_msg_t *msg, uint32_t routing_id);
+ZMQ_EXPORT uint32_t zmq_msg_routing_id(zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_set_group(zmq_msg_t *msg, const char *group);
+ZMQ_EXPORT const char *zmq_msg_group(zmq_msg_t *msg);
+
+/******************************************************************************/
+/*  Poller polling on sockets,fd and thread-safe sockets                      */
+/******************************************************************************/
+
+#define ZMQ_HAVE_POLLER
+
+typedef struct zmq_poller_event_t
+{
+    void *socket;
+#if defined _WIN32
+    SOCKET fd;
+#else
+    int fd;
+#endif
+    void *user_data;
+    short events;
+} zmq_poller_event_t;
+
+ZMQ_EXPORT void *zmq_poller_new (void);
+ZMQ_EXPORT int  zmq_poller_destroy (void **poller_p);
+ZMQ_EXPORT int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
+ZMQ_EXPORT int  zmq_poller_modify (void *poller, void *socket, short events);
+ZMQ_EXPORT int  zmq_poller_remove (void *poller, void *socket);
+ZMQ_EXPORT int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
+ZMQ_EXPORT int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, int n_events, long timeout);
+
+#if defined _WIN32
+ZMQ_EXPORT int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
+ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, SOCKET fd, short events);
+ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, SOCKET fd);
+#else
+ZMQ_EXPORT int zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
+ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
+ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
+#endif
+
+/******************************************************************************/
+/*  Scheduling timers                                                         */
+/******************************************************************************/
+
+#define ZMQ_HAVE_TIMERS
+
+typedef void (zmq_timer_fn)(int timer_id, void *arg);
+
+ZMQ_EXPORT void *zmq_timers_new (void);
+ZMQ_EXPORT int   zmq_timers_destroy (void **timers_p);
+ZMQ_EXPORT int   zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
+ZMQ_EXPORT int   zmq_timers_cancel (void *timers, int timer_id);
+ZMQ_EXPORT int   zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
+ZMQ_EXPORT int   zmq_timers_reset (void *timers, int timer_id);
+ZMQ_EXPORT long  zmq_timers_timeout (void *timers);
+ZMQ_EXPORT int   zmq_timers_execute (void *timers);
+
+#endif // ZMQ_BUILD_DRAFT_API
+
+
 #undef ZMQ_EXPORT
 
 #ifdef __cplusplus
@@ -470,4 +629,3 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #endif
 
 #endif
-

--- a/windows/include/zmq_utils.h
+++ b/windows/include/zmq_utils.h
@@ -1,20 +1,48 @@
 /*
-    Copyright (c) 2007-2015 Contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2016 Contributors as noted in the AUTHORS file
 
-    This file is part of 0MQ.
+    This file is part of libzmq, the ZeroMQ core engine in C++.
 
-    0MQ is free software; you can redistribute it and/or modify it under
-    the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
     (at your option) any later version.
 
-    0MQ is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
 
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 /*  This file is deprecated, and all its functionality provided by zmq.h     */
+/*  Note that -Wpedantic compilation requires GCC to avoid using its custom
+    extensions such as #warning, hence the trick below. Also, pragmas for
+    warnings or other messages are not standard, not portable, and not all
+    compilers even have an equivalent concept.
+    So in the worst case, this include file is treated as silently empty. */
+
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__) || defined(_MSC_VER)
+#if defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcpp"
+#pragma GCC diagnostic ignored "-Werror"
+#pragma GCC diagnostic ignored "-Wall"
+#endif
+#pragma message("Warning: zmq_utils.h is deprecated. All its functionality is provided by zmq.h.")
+#if defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
+#endif


### PR DESCRIPTION
This also simplifies the build script and move the essential stuff to cross platform js.
It will  make it possible to build libzmq from source on windows if someone writes a batch script handling the build.