### PR TITLE
Bump prebuild@4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "nan": "^2.4.0",
-    "prebuild": "^4.2.2"
+    "prebuild": "^4.4.0"
   },
   "devDependencies": {
     "electron-mocha": "^3.1.1",


### PR DESCRIPTION
This version is required to correctly build `zeromq`.