### PR TITLE
Don't recompile libzmq if already built

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "scripts": {
     "build:libzmq": "node scripts/preinstall.js",
     "install": "prebuild --install --preinstall \"npm run build:libzmq\"",
-    "rebuild": "prebuild --compile",
     "prebuild": "prebuild --all --strip",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
     "test": "mocha --expose-gc --slow 300",

--- a/scripts/build_libzmq.sh
+++ b/scripts/build_libzmq.sh
@@ -26,3 +26,4 @@ make install
 
 cd $ZMQ_PREFIX
 rm -rf $ZMQ_SRC_DIR
+rm -f zeromq-$ZMQ.tar.gz


### PR DESCRIPTION
Skip compilation of libzmq if already built. This will speed up subsequent builds.

/cc @n-riesco