### PR TITLE
scripts: Fixes deprecated use of `--with-relaxed`

### DIFF
--- a/scripts/build_libzmq.sh
+++ b/scripts/build_libzmq.sh
@@ -21,7 +21,11 @@ test -d "${ZMQ_SRC_DIR}" || tar xzf zeromq-$ZMQ.tar.gz
 cd "${ZMQ_SRC_DIR}"
 
 test -f configure || ./autogen.sh
-./configure "--prefix=${ZMQ_PREFIX}" --with-relaxed --enable-static --disable-shared
+if [ "$ZMQ" = "4.1.6" ]; then
+  ./configure "--prefix=${ZMQ_PREFIX}" --with-relaxed --enable-static --disable-shared ;
+else
+  ./configure "--prefix=${ZMQ_PREFIX}" --disable-pedantic --enable-static --disable-shared ;
+fi
 make -j 2
 make install
 


### PR DESCRIPTION
* From
  https://github.com/nteract/nteract/issues/1189#issuecomment-260534970

* See
  https://github.com/zeromq/libzmq/commit/7129187f877317fe6af8a5ece3638782ceb0d602