### PR TITLE
Socket::Socket: Don't throw a C++ exception

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -552,7 +552,8 @@ namespace zmq {
     size_t len = sizeof(uv_os_sock_t);
 
     if (zmq_getsockopt(socket_, ZMQ_FD, &socket, &len)) {
-      throw std::runtime_error(ErrorMessage());
+      Nan::ThrowError(ErrorMessage());
+      return;
     }
 
     #if ZMQ_CAN_MONITOR


### PR DESCRIPTION
Fixes https://github.com/nteract/hydrogen/issues/515

(needs testing since I can't reproduce the issue in Hydrogen)