### PR TITLE
binding.cc: Don't throw cpp exceptions

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -988,12 +988,12 @@ namespace zmq {
         public:
           inline MessageReference() {
             if (zmq_msg_init(&msg_) < 0)
-              throw std::runtime_error(ErrorMessage());
+              Nan::ThrowError(ErrorMessage());
           }
 
           inline ~MessageReference() {
             if (zmq_msg_close(&msg_) < 0)
-              throw std::runtime_error(ErrorMessage());
+              Nan::ThrowError(ErrorMessage());
           }
 
           inline operator zmq_msg_t*() {

--- a/binding.cc
+++ b/binding.cc
@@ -1400,8 +1400,10 @@ namespace zmq {
   void
   Socket::Close() {
     if (socket_) {
-      if (zmq_close(socket_) < 0)
-        throw std::runtime_error(ErrorMessage());
+      if (zmq_close(socket_) < 0) {
+        Nan::ThrowError(ErrorMessage());
+        return;
+      }
       socket_ = NULL;
       state_ = STATE_CLOSED;
       context_.Reset();

--- a/binding.cc
+++ b/binding.cc
@@ -1060,8 +1060,10 @@ namespace zmq {
     zmq_socket_monitor(this->socket_, NULL, ZMQ_EVENT_ALL);
 
     // Close the monitor socket and stop timer
-    if (zmq_close(this->monitor_socket_) < 0)
-      throw std::runtime_error(ErrorMessage());
+    if (zmq_close(this->monitor_socket_) < 0) {
+      Nan::ThrowError(ErrorMessage());
+      return;
+    }
     uv_timer_stop(this->monitor_handle_);
     this->monitor_handle_ = NULL;
     this->monitor_socket_ = NULL;

--- a/binding.cc
+++ b/binding.cc
@@ -1195,13 +1195,13 @@ namespace zmq {
         if (zmq_msg_init_data(&msg_, Buffer::Data(buf), Buffer::Length(buf),
             BufferReference::FreeCallback, bufref_) < 0) {
           delete bufref_;
-          throw std::runtime_error(ErrorMessage());
+          Nan::ThrowError(ErrorMessage());
         }
       };
 
       inline ~OutgoingMessage() {
         if (zmq_msg_close(&msg_) < 0)
-          throw std::runtime_error(ErrorMessage());
+          Nan::ThrowError(ErrorMessage());
       };
 
       inline operator zmq_msg_t*() {

--- a/binding.cc
+++ b/binding.cc
@@ -240,7 +240,7 @@ namespace zmq {
 
   Context::Context(int io_threads) : Nan::ObjectWrap() {
     context_ = zmq_init(io_threads);
-    if (!context_) throw std::runtime_error(ErrorMessage());
+    if (!context_) Nan::ThrowError(ErrorMessage());
   }
 
   Context *
@@ -251,7 +251,10 @@ namespace zmq {
   void
   Context::Close() {
     if (context_ != NULL) {
-      if (zmq_term(context_) < 0) throw std::runtime_error(ErrorMessage());
+      if (zmq_term(context_) < 0) {
+        Nan::ThrowError(ErrorMessage());
+        return;
+      }
       context_ = NULL;
     }
   }

--- a/binding.cc
+++ b/binding.cc
@@ -374,8 +374,10 @@ namespace zmq {
       if (rc < 0) {
         if (zmq_errno()==EINTR) {
           continue;
+        } else {
+          Nan::ThrowError(ErrorMessage());
+          return -1;
         }
-        throw std::runtime_error(ErrorMessage());
       } else {
         break;
       }


### PR DESCRIPTION
This PR removes the remaining `throw std::runtime_error(ErrorMessage());` in `binding.cc`.

Re: https://github.com/zeromq/zeromq.js/pull/104
