### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET=10.9 for libzmq build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
         ['OS=="mac" or OS=="solaris"', {
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+            'MACOSX_DEPLOYMENT_TARGET': '10.9',
           },
           'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
           'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],

--- a/scripts/build_libzmq.sh
+++ b/scripts/build_libzmq.sh
@@ -8,6 +8,7 @@ else
   exit 1
 fi
 
+export MACOSX_DEPLOYMENT_TARGET=10.9
 export BASE=$(dirname "$0")
 export ZMQ_PREFIX="${BASE}/../zmq"
 export ZMQ_SRC_DIR=zeromq-$ZMQ


### PR DESCRIPTION
Thanks to @minrk https://github.com/zeromq/libzmq/issues/2175#issuecomment-263225619, I noticed we only set `MACOSX_DEPLOYMENT_TARGET` in the gyp build and not for building libzmq it self.

I tried to stick with `MACOSX_DEPLOYMENT_TARGET=10.7` but this throws an error on macOS:
```
dyld: lazy symbol binding failed: Symbol not found: __ZNSsC1Ev
  Referenced from: /Users/lukasgeiger/code/zmq-prebuilt/build/Release/zmq.node
  Expected in: flat namespace

dyld: Symbol not found: __ZNSsC1Ev
  Referenced from: /Users/lukasgeiger/code/zmq-prebuilt/build/Release/zmq.node
  Expected in: flat namespace
```

`MACOSX_DEPLOYMENT_TARGET=10.9` is the minimal target that works on my macOS 10.12 machine.

/cc @rgbkrk 