### PR TITLE
Trigger tests of prebuilts on postpublish

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Build Status](https://travis-ci.org/zeromq/zeromq.js.svg?branch=master)](https://travis-ci.org/zeromq/zeromq.js)
 [![Build status](https://ci.appveyor.com/api/projects/status/6u7saauir2msxpou?svg=true)](https://ci.appveyor.com/project/zeromq/zeromq.js)
 [![](https://img.shields.io/badge/version-stable-blue.svg)](https://github.com/zeromq/zeromq.js/releases)
-[![Build Status](https://travis-ci.org/nteract/zmq-prebuilt-testing.svg?branch=master)](https://travis-ci.org/nteract/zmq-prebuilt-testing)
-[![Build status](https://ci.appveyor.com/api/projects/status/ox85p208tsxw6vt1?svg=true)](https://ci.appveyor.com/project/nteract/zmq-prebuilt-testing)
+[![Build Status](https://travis-ci.org/zeromq/zeromq.js.svg?branch=prebuilt-testing)](https://travis-ci.org/zeromq/zeromq.js)
+[![Build status](https://ci.appveyor.com/api/projects/status/w189dgubmg9darun/branch/master?svg=true)](https://ci.appveyor.com/project/zeromq/zeromq-js/branch/prebuilt-testing)
 
 [**Users**](#installation---users) | [**From Source**](#installation---from-source) | [**Contributors and Development**](#installation---contributors-and-development) | [**Maintainers**](#for-maintainers-creating-a-release)
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "install": "prebuild --install --preinstall \"npm run build:libzmq\"",
     "prebuild": "prebuild --all --strip",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
+    "postpublish": "./scripts/trigger_travis_build.sh",
     "test": "mocha --expose-gc --slow 300",
     "test:electron": "electron-mocha --slow 300",
     "precoverage": "nyc npm run test",

--- a/scripts/trigger_travis_build.sh
+++ b/scripts/trigger_travis_build.sh
@@ -1,4 +1,4 @@
-body='{
+travis_body='{
 "request": {
   "message": "Test prebuilt binaries",
   "branch": "prebuilt-testing"
@@ -9,5 +9,18 @@ curl -s -X POST \
   -H "Accept: application/json" \
   -H "Travis-API-Version: 3" \
   -H "Authorization: token $TRAVIS_TOKEN" \
-  -d "$body" \
+  -d "$travis_body" \
   https://api.travis-ci.org/repo/zeromq%2Fzeromq.js/requests
+
+appveyor_body='{
+  "accountName": "zeromq",
+  "projectSlug": "zeromq-js",
+  "branch": "prebuilt-testing",
+}'
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer $APPVEYOR_TOKEN" \
+  -d "$appveyor_body" \
+  https://ci.appveyor.com/api/builds

--- a/scripts/trigger_travis_build.sh
+++ b/scripts/trigger_travis_build.sh
@@ -1,0 +1,13 @@
+body='{
+"request": {
+  "message": "Test prebuilt binaries",
+  "branch": "prebuilt-testing"
+}}'
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token $TRAVIS_TOKEN" \
+  -d "$body" \
+  https://api.travis-ci.org/repo/zeromq%2Fzeromq.js/requests


### PR DESCRIPTION
A new CI build will be triggered automatically given the environment variable `$TRAVIS_TOKEN` is set: https://github.com/zeromq/zeromq.js/tree/prebuilt-testing