### PR TITLE
Bump prebuild-install@2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/zeromq/zeromq.js.git"
   },
   "dependencies": {
-    "@lgeiger/prebuild-install": "^2.0.1",
+    "@lgeiger/prebuild-install": "^2.0.2",
     "nan": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`prebuild-install@2.0.1` Didn't correctly handle `--target` and `--runtime`. This broke downloading for electron.