### PR TITLE
Upgraded preinstall script for new ZMQ 4.2.2 windows binaries

### DIFF
--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -53,7 +53,7 @@ function handleError(err) {
 
 if (process.platform === "win32") {
   var LIB_URL =
-    "https://github.com/nteract/libzmq-win/releases/download/v2.0.0/libzmq-" +
+    "https://github.com/nteract/libzmq-win/releases/download/v2.1.0/libzmq-" +
     ZMQ +
     "-" +
     process.arch +

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -9,7 +9,7 @@ if (process.platform == "linux") {
   ZMQ = "4.1.6";
   ZMQ_REPO = "zeromq4-1";
 } else {
-  ZMQ = "4.2.0";
+  ZMQ = "4.2.2";
   ZMQ_REPO = "libzmq";
 }
 


### PR DESCRIPTION
This brings the new binaries compiled with TweetNacl, which fixes everything I was asking in comments of the issue #102.