### PR TITLE
Allow building with libzmq shared library

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ npm install zeromq
 
 Now, prepare to be amazed by the wonders of binaries.
 
+To use your system's libzmq (if it has been installed and development headers
+are available):
+
+```bash
+npm install zeromq --zmq-external
+```
+
 ### Rebuilding for Electron
 
 If you want to use `zeromq` inside your [Electron](http://electron.atom.io/) application

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
       'cflags!': ['-fno-exceptions'],
       'cflags_cc!': ['-fno-exceptions'],
       'conditions': [
-        ["zmq_external", {
+        ["zmq_external == 'true'", {
           'link_settings': {
             'libraries': ['-lzmq'],
           },

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,37 +1,48 @@
 {
+  'variables': {
+    'zmq_external%': 'false',
+  },
   'targets': [
     {
       'target_name': 'zmq',
-      'sources': [ 'binding.cc' ],
+      'sources': ['binding.cc'],
       'include_dirs' : ["<!(node -e \"require('nan')\")"],
       'cflags!': ['-fno-exceptions'],
       'cflags_cc!': ['-fno-exceptions'],
       'conditions': [
-        ['OS=="win"', {
-          'msbuild_toolset': 'v140',
-          'defines': ['ZMQ_STATIC'],
-          'include_dirs': ['windows/include'],
-          'libraries': [
-            '<(PRODUCT_DIR)/../../windows/lib/libzmq',
-            'ws2_32.lib',
-            'iphlpapi'
+        ["zmq_external", {
+          'link_settings': {
+            'libraries': ['-lzmq'],
+          },
+        }, {
+          'conditions': [
+            ['OS=="win"', {
+              'msbuild_toolset': 'v140',
+              'defines': ['ZMQ_STATIC'],
+              'include_dirs': ['windows/include'],
+              'libraries': [
+                '<(PRODUCT_DIR)/../../windows/lib/libzmq',
+                'ws2_32.lib',
+                'iphlpapi',
+              ],
+            }],
+            ['OS=="mac" or OS=="solaris"', {
+              'xcode_settings': {
+                'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                'MACOSX_DEPLOYMENT_TARGET': '10.9',
+              },
+              'libraries': ['<(PRODUCT_DIR)/../../zmq/lib/libzmq.a'],
+              'include_dirs': ['<(PRODUCT_DIR)/../../zmq/include'],
+            }],
+            ['OS=="openbsd" or OS=="freebsd"', {
+            }],
+            ['OS=="linux"', {
+              'libraries': ['<(PRODUCT_DIR)/../../zmq/lib/libzmq.a'],
+              'include_dirs': ['<(PRODUCT_DIR)/../../zmq/include'],
+            }],
           ],
         }],
-        ['OS=="mac" or OS=="solaris"', {
-          'xcode_settings': {
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-            'MACOSX_DEPLOYMENT_TARGET': '10.9',
-          },
-          'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
-          'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],
-        }],
-        ['OS=="openbsd" or OS=="freebsd"', {
-        }],
-        ['OS=="linux"', {
-          'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
-          'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],
-        }],
-      ]
+      ],
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build:libzmq": "node scripts/preinstall.js",
-    "install": "node scripts/prebuild-install.js || (npm run build:libzmq && node-gyp rebuild)",
+    "install": "node scripts/prebuild-install.js || (node scripts/preinstall.js && node-gyp rebuild)",
     "prebuild": "prebuild --all --strip",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
     "postpublish": "./scripts/trigger_travis_build.sh",

--- a/scripts/prebuild-install.js
+++ b/scripts/prebuild-install.js
@@ -4,6 +4,11 @@ var pbi = 'prebuild-install';
 var platform = process.platform;
 var arch = process.arch;
 
+if (process.env.npm_config_zmq_external == "true") {
+  /* Requested to use external libzmq, we must rebuild. */
+  process.exit(1);
+}
+
 if (
   platform === 'linux' &&
   (arch === 'arm' || arch === 'arm64')

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -6,6 +6,11 @@ var fs = require("fs");
 var ZMQ = "4.2.2";
 var ZMQ_REPO = "libzmq";
 
+if (process.env.npm_config_zmq_external == "true") {
+  console.log("Skipping libzmq build");
+  process.exit(0);
+}
+
 function buildZMQ(scriptPath, zmqDir) {
   console.log("Building libzmq for " + process.platform);
 


### PR DESCRIPTION
Currently the only option to use these bindings is with a (prebuilt) binary that statically links zmq.

On our systems we prefer to use dynamic linking because our OS images already contain libzmq. This patch introduces an option (disabled by default) that allows using libzmq shared library if it has already been installed.

`npm install --zmq-external`

Or alternatively (with another package manager for example):

`npm_config_zmq_external=true yarn install`

In addition to changing how the bindings are linked; downloading prebuilt binaries and building the static library will be skipped if this option is enabled.