### PR TITLE
Avoid leaking file descriptors and memory for monitored sockets

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -340,6 +340,7 @@ namespace zmq {
   }
 
   Socket::~Socket() {
+    Unmonitor();
     Close();
   }
 


### PR DESCRIPTION
Currently it is required to call `socket.unmonitor()` before a monitored socket goes out of scope.

The monitoring socket is never released, which causes the monitoring socket to stay around indefinitely. This causes a memory leak and a file descriptor leak. The latter causes the process to run out of file descriptors eventually.

I don't think it should be required to call `unmonitor()` before a socket is gc'ed – maybe it's not even feasible to always do this (depends on the application I guess).

This simple change calls `Socket::Unmonitor()` internally in the destructor. This is safe because `Socket::Unmonitor()` already checks to see if a socket is monitored, and is a no-op if it wasn't.

Not really sure if this requires any new tests. I wouldn't know how to write a unit test for this, honestly.