### PR TITLE
Add getter for socket closed state

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -413,6 +413,13 @@ Object.keys(opts).forEach(function(name){
 });
 
 /**
+ * Return true if socket state is closed.
+ */
+Socket.prototype.__defineGetter__("closed", function() {
+  return this._zmq.state === zmq.STATE_CLOSED;
+});
+
+/**
  * Async bind.
  *
  * Emits the "bind" event.

--- a/test/socket.js
+++ b/test/socket.js
@@ -35,7 +35,9 @@ describe('socket', function(){
   });
 
   it('should close', function(){
+    sock.closed.should.equal(false);
     sock.close();
+    sock.closed.should.equal(true);
   });
 
   it('should support options', function(){


### PR DESCRIPTION
In my code I have found it useful to be able to determine if a socket is closed. This is information is already kept in a `state` variable in the C++ bindings, but not exposed as public API.

This PR proposes to add a `socket.closed` getter, which returns a boolean.

(An alternative implementation would be a `socket.state` getter which returns the socket's internal state. Which state values are possible would not be immediately obvious to me, so I'm proposing this boolean getter instead.)

The background of being able to check if a socket is closed is that some monitor events (and other events in my application) can occur slightly out of order due to timing issues native to how Node works. As such it is nice to avoid calling `socket.send()` or something similar if the socket was already closed with `socket.close()` as a result of another event. Of course I could keep this state in my application, but that seems needlessly complex given that the bindings **already** keep track of the state of the socket!