### PR TITLE
Zero copy message sending

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -48,6 +48,8 @@
 #define ZMQ_CAN_MONITOR (ZMQ_VERSION > 30201)
 #define ZMQ_CAN_SET_CTX (ZMQ_VERSION_MAJOR == 3 && ZMQ_VERSION_MINOR >= 2) || ZMQ_VERSION_MAJOR > 3
 
+#define ZERO_COPY_MESSAGE_SEND 1
+
 using namespace v8;
 using namespace node;
 
@@ -1294,12 +1296,13 @@ namespace zmq {
 
       int flags = Nan::To<int>(flagsObj).FromJust();
 
-#if 1
+#if ZERO_COPY_MESSAGE_SEND
       /* Non-copying implementation. */
       OutgoingMessage msg_p(buf);
 #else
       /* Copying implementation. */
       zmq_msg_t msg;
+      int rc;
       size_t len = Buffer::Length(buf);
       rc = zmq_msg_init_size(&msg, len);
       if (rc != 0)

--- a/binding.cc
+++ b/binding.cc
@@ -1053,8 +1053,9 @@ namespace zmq {
               delete async_;
               delete this;
               Nan::ThrowError("Async initialization failed");
+            } else {
+              async_->data = this;
             }
-            async_->data = this;
           }
 
           inline ~BufferReference() {


### PR DESCRIPTION
I'm sending relatively large messages with zeromq and noticed in the internals that there was an opportunity for using zeromq's zero-copy message initialisation on send.

Apparently this has been attempted before in the past, but is no longer used, and is annotated with the following comment:

> zero-copy version, but doesn't properly pin buffer and so has GC issues

I don't know what is meant by "pinning a buffer", but there was indeed a bug in the zero-copy implementation – it did not call `uv_close` for the allocated `uv_async_t`. Also, the implementation was in the (now unused) `Socket::Send` method.

This PR changes the following:
- Get rid of unused `Socket::Send`
- Reinstate zero-copy implementation with bugfix that calls `uv_close` when the outgoing message is released
- Apply zero-copy implementation to `Socket::Sendv`, which is the method that is called by the JS code
- Keep copying implementation with a `#define` flag to compare the two implementations
- Enable zero-copy by default

I [benchmarked](https://gist.github.com/rolftimmermans/91066783f44951fc1e1a70ed38a670fe) the two implementations with a benchmark. It sends 200 messages of 1MB each on a socket that is not connected. The benchmark is very synthetic, obviously, but it only serves to demonstrate the result of this change.

#### Copying implementation
`> time node --expose-gc zmq-zero-copy-bench.js`
```
{ rss: 22106112,
  heapTotal: 8425472,
  heapUsed: 3223464,
  external: 8380 }
{ rss: 657149952,
  heapTotal: 11571200,
  heapUsed: 3312960,
  external: 92283068 }

real	0m0.705s
user	0m0.311s
sys	0m0.400s
```

#### Zero-copy implementation
`> time node --expose-gc zmq-zero-copy-bench.js`
```
{ rss: 22482944,
  heapTotal: 8425472,
  heapUsed: 3223464,
  external: 8380 }
{ rss: 24731648,
  heapTotal: 10522624,
  heapUsed: 3397760,
  external: 524296380 }

real	0m0.104s
user	0m0.084s
sys	0m0.021s
```

The zero-copy implementation is a lot faster if we only benchmark the queueing of messages with `socket.send()` to zeromq internally. (A previous version of this PR/benchmark used `crypto.randomBytes` which severely distorted results – and should be ignored.)

I'm not entirely sure how to interpret the memory usage. It should be better because no messages need to be copied, but with V8's GC I find this hard to demonstrate.

I understand this might be considered a risky change. I would appreciate if someone could review it and if it could be discussed if this is worth merging.

We have been using this in production for a week or so without any apparent issues. We are using Node v6.11.0/v6.11.2. It might be worth testing this extensively with different versions too. I'll see if I can make some time for that.