### PR TITLE
Made the package compile in termux on android

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
       'cflags!': ['-fno-exceptions'],
       'cflags_cc!': ['-fno-exceptions'],
       'conditions': [
-        ["zmq_external == 'true'", {
+        ["zmq_external == 'true'" or "OS==android", {
           'link_settings': {
             'libraries': ['-lzmq'],
           },

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
       'cflags!': ['-fno-exceptions'],
       'cflags_cc!': ['-fno-exceptions'],
       'conditions': [
-        ["zmq_external == 'true'" or "OS==android", {
+        ["zmq_external == 'true'", {
           'link_settings': {
             'libraries': ['-lzmq'],
           },
@@ -41,6 +41,7 @@
               'include_dirs': ['<(PRODUCT_DIR)/../../zmq/include'],
             }],
             ['OS=="android"', {
+              'libraries': ['-lzmq'],
               'cflags': ['-fPIC'],
               'cflags_cc': ['-fPIC'],
             }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -40,6 +40,10 @@
               'libraries': ['<(PRODUCT_DIR)/../../zmq/lib/libzmq.a'],
               'include_dirs': ['<(PRODUCT_DIR)/../../zmq/include'],
             }],
+            ['OS=="android"', {
+              'cflags': ['-fPIC'],
+              'cflags_cc': ['-fPIC'],
+            }],
           ],
         }],
       ],


### PR DESCRIPTION
To compile the package in the termux app on android you have to compile the sources with the compiler flag "-fPIC". I added this in an special condition branch. The compiled package is working properly within the following constellation ijavascript -> jp-kernel -> jmp -> zeromq.js