### PR TITLE
scripts: fix build against node-x86

### DIFF
--- a/scripts/build_libzmq.sh
+++ b/scripts/build_libzmq.sh
@@ -8,14 +8,20 @@ else
   exit 1
 fi
 
+if [ "$2" = "ia32" ]; then
+  export CFLAGS="-fPIC -m32"
+  export CXXFLAGS="-fPIC -m32"
+else
+  export CFLAGS=-fPIC
+  export CXXFLAGS=-fPIC
+fi
+
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export BASE=$(dirname "$0")
 export ZMQ_PREFIX="${BASE}/../zmq"
 export ZMQ_SRC_DIR=zeromq-$ZMQ
 cd "${ZMQ_PREFIX}"
 
-export CFLAGS=-fPIC
-export CXXFLAGS=-fPIC
 export PKG_CONFIG_PATH="${ZMQ_PREFIX}/lib/pkgconfig"
 
 test -d "${ZMQ_SRC_DIR}" || tar xzf zeromq-$ZMQ.tar.gz

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -3,6 +3,7 @@ var spawn = require("child_process").spawn;
 var path = require("path");
 var fs = require("fs");
 
+var ARCH = process.arch;
 var ZMQ = "4.2.2";
 var ZMQ_REPO = "libzmq";
 
@@ -14,7 +15,7 @@ if (process.env.npm_config_zmq_external == "true") {
 function buildZMQ(scriptPath, zmqDir) {
   console.log("Building libzmq for " + process.platform);
 
-  var child = spawn(scriptPath, [ZMQ]);
+  var child = spawn(scriptPath, [ZMQ, ARCH]);
 
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stderr);


### PR DESCRIPTION
* Added flag `-m32` when arch is `ia32`.

Fixes #214