### PR TITLE
Delete uv_timer_t when unmonitoring socket

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1141,6 +1141,7 @@ namespace zmq {
       return;
     }
     uv_timer_stop(this->monitor_handle_);
+    uv_close(reinterpret_cast<uv_handle_t*>(this->monitor_handle_), on_uv_close);
     this->monitor_handle_ = NULL;
     this->monitor_socket_ = NULL;
   }


### PR DESCRIPTION
I was looking for a memory leak in an application that creates lots of short lived monitored sockets. Running valgrind against the application showed that the `uv_timer_t` used to monitor sockets is never deleted.

This is a section of the valgrind output after running the application for an hour.
```
==27487== 2,491,736 bytes in 16,393 blocks are possibly lost in loss record 1,514 of 1,518
==27487==    at 0x4C2E19F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27487==    by 0xAE2354F: zmq::Socket::Monitor(Nan::FunctionCallbackInfo<v8::Value> const&) (binding.cc:1058)
==27487==    by 0xAE1F0BB: Nan::imp::FunctionCallbackWrapper(v8::FunctionCallbackInfo<v8::Value> const&) (nan_callbacks_12_inl.h:174)
```

`binding.cc` line 1058 was the line with `new uv_timer_t` in the latest release (4.6.0)
```
    if(zmq_socket_monitor(socket->socket_, addr, ZMQ_EVENT_ALL) != -1) {
      socket->monitor_socket_ = zmq_socket (context->context_, ZMQ_PAIR);
      zmq_connect (socket->monitor_socket_, addr);
      socket->timer_interval_ = timer_interval;
      socket->num_of_events_ = num_of_events;
      socket->monitor_handle_ = new uv_timer_t;
      socket->monitor_handle_->data = socket;

      uv_timer_init(uv_default_loop(), socket->monitor_handle_);
      uv_timer_start(socket->monitor_handle_, reinterpret_cast<uv_timer_cb>(Socket::UV_MonitorCallback), timer_interval, 0);
    }
```

Adding a `uv_close` callback to delete the `uv_timer_t` in `Socket::Unmonitor` fixes the issue in my application.

This issue https://github.com/JustinTulloss/zeromq.node/issues/455 in the previous repo claims that `new uv_timer_t` is not a memory leak, but it clearly is. It also says that `uv_close` is not safe to use here. Can someone with more experience with the ZMQ Node bindings comment?

And a Happy New Year to all of you contributing and maintaining this project!