### PR TITLE
align our required version to the current LTS+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zeromq",
   "version": "4.6.0",
-  "description": "Prebuilt bindings for node.js to ZeroMQ",
+  "description": "ZeroMQ for node.js",
   "main": "index",
   "gypfile": true,
   "repository": {
@@ -22,7 +22,7 @@
     "should": "^13.0.0"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=6.0"
   },
   "scripts": {
     "build:libzmq": "node scripts/preinstall.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "nan": "^2.10.0",
-    "prebuild-install": "4.0.0"
+    "prebuild-install": "5.0.0"
   },
   "devDependencies": {
     "electron-mocha": "^6.0.0",


### PR DESCRIPTION
Also changed our tagline / description for the package.json. I'd like to get 4.7.0 out. 

Went ahead and upgraded the version of prebuild-install while I was at it. I think that's _most_ of the maintenance level tasks that are needed here.

Closes #263