### PR TITLE
Keep multipart messages in router/dealer proxy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -824,25 +824,25 @@ function proxy (frontend, backend, capture){
 
         //forwarding router/dealer pack signature: id, delimiter, msg
         frontend.on('message',function (id,delimiter,msg){
-          backend.send([id,delimiter,msg]);
+          backend.send([].slice.call(arguments));
         });
 
         backend.on('message',function (id,delimiter,msg){
-          frontend.send([id,delimiter,msg]);
+          frontend.send([].slice.call(arguments));
 
           //forwarding message to the capture socket
-          capture.send(msg);
+          capture.send([].slice.call(arguments, 2));
         });
 
       } else {
 
         //forwarding router/dealer signatures without capture
         frontend.on('message',function (id,delimiter,msg){
-          backend.send([id,delimiter,msg]);
+          backend.send([].slice.call(arguments));
         });
 
         backend.on('message',function (id,delimiter,msg){
-          frontend.send([id,delimiter,msg]);
+          frontend.send([].slice.call(arguments));
         });
 
       }


### PR DESCRIPTION
This is to solve [issue 277](https://github.com/zeromq/zeromq.js/issues/277)
Basically just reused existing [fix for xpub/xsub proxy](https://github.com/JustinTulloss/zeromq.node/pull/593/commits/2c0ac29e5c96e5d3a41e6d145237ca079009f549)

