### PR TITLE
Add Node.js 11 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - "6"
 - "8"
 - "10"
+- "11"
 sudo: required
 
 matrix:


### PR DESCRIPTION
Add Node.js 11 test so we can publish a new release to support the v67 prebuild binaries.