### PR TITLE
Pass environment variables to prebuild-install

### DIFF
--- a/scripts/prebuild-install.js
+++ b/scripts/prebuild-install.js
@@ -17,7 +17,11 @@ if (
   pbi += ' --arch=armv' + armv;
 }
 
-exec(pbi, function(err, stdout, stderr) {
+var options = {
+  env: process.env,
+};
+
+exec(pbi, options, function(err, stdout, stderr) {
   console.log(stdout);
   console.log(stderr);
   if (err) process.exit(1);


### PR DESCRIPTION
Per the [`prebuild-install` documentation](https://github.com/prebuild/prebuild-install#custom-binaries), end users should be able to pass environment variables to change where `prebuild` looks for its binaries.  Currently, `scripts/prebuild-install.js` filters out these variables. This PR passes them on.