### PR TITLE
Upgrade prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "url": "https://github.com/zeromq/zeromq.js.git"
   },
   "dependencies": {
-    "nan": "^2.10.0",
-    "prebuild-install": "5.2.1"
+    "nan": "^2.14.0",
+    "prebuild-install": "^5.3.2"
   },
   "devDependencies": {
     "electron-mocha": "^6.0.0",
     "jsdoc": "^3.5.4",
     "mocha": "^5.0.0",
     "nyc": "^12.0.2",
-    "prebuild": "^8.1.0",
+    "prebuild": "^9.1.1",
     "semver": "^5.4.1",
     "should": "^13.0.0"
   },


### PR DESCRIPTION
It looks like the latest release included broken prebuilt binaries due to a version conflict between Node and Electron. See https://github.com/prebuild/prebuild/pull/261 and https://github.com/prebuild/prebuild/issues/249

The upgrade hopefully fixes #338

Note I made the PR against the `5.x` to not conflict with #343 