### PR TITLE
Pin node-abi to not build for Electron v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "electron-mocha": "^6.0.0",
     "jsdoc": "^3.5.4",
     "mocha": "^5.0.0",
+    "node-abi": "2.11.0",
     "nyc": "^12.0.2",
     "prebuild": "^9.1.1",
     "semver": "^5.4.1",


### PR DESCRIPTION
Electron v7 was just released. Unfortunately this makes the zeromq build fail, so the last patch release didn't build on CI. This pins the version of `node-abi` so the Electron v7 build is ignored.