### PR TITLE
Added support for Node 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - "8"
 - "10"
 - "11"
+- "13"
 sudo: required
 
 matrix:

--- a/binding.cc
+++ b/binding.cc
@@ -1297,8 +1297,8 @@ namespace zmq {
         }
       }
 
-      Local<Object> buf = batch->Get(i).As<Object>();
-      Local<Number> flagsObj = batch->Get(i + 1).As<Number>();
+      Local<Object> buf = batch->Get(Nan::GetCurrentContext(), i).ToLocalChecked().As<Object>();
+      Local<Number> flagsObj = batch->Get(Nan::GetCurrentContext(), i + 1).ToLocalChecked().As<Number>();
 
       int flags = Nan::To<int>(flagsObj).FromJust();
 


### PR DESCRIPTION
As mentioned in #346, this library fails to install with Node 13.0.1, due to compilation errors.
After a quick investigation, the issue seems to be
```c++
v8::Local<v8::Value> v8::Object::Get(uint32_t index)
``` 
which [has already been deprecated for a while](https://v8docs.nodesource.com/node-12.0/db/d85/classv8_1_1_object.html#af8c3c8fa1256e7ea440616e82b461d31) and seems to have been removed in favour of
```c++
v8::MaybeLocal<v8::Value> v8::Object::Get(v8::Local<v8::Context> context, uint32_t index)
```
in Node 13 / V8 7.8.

This seems to fix the issue.

It's only been tested with Node 12.13.0 and 13.0.1, on Windows.

This might break compatibility with older versions of Node, however [the new method was already present](https://v8docs.nodesource.com/node-6.17/db/d85/classv8_1_1_object.html#a5552867a276e2bda013de11e8ba41e4f) ([and the old one was already deprecated](https://v8docs.nodesource.com/node-6.17/db/d85/classv8_1_1_object.html#af8c3c8fa1256e7ea440616e82b461d31)) in Node 6 / V8 5.1, so it shouldn't be the case.

It might not be the best way to fix it, but works for me.