### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Reproducing**
+If possible, provide a list of commands or a code sample that reproduces the bug that you are observing. Otherwise please describe as much as possible in which circumstances the bug can be observed.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Tested on**
+ - OS: [e.g. Ubuntu 18.04, Windows 10]
+ - ZeroMQ.js version: [e.g. 5.1.0, 6.0.0-beta.2]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. 
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
I thought it would be good to have some more guidance for users what information to provide when reporting bugs or proposing new features.

This uses Github's issue templates feature to display placeholder issue content when opening a new issue. Users have the option to select "Bug report" or "Feature request", but we can add whichever type we want.

What do you think?