### PR TITLE
Revert "Pin node-abi to not build for Electron v7"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "electron-mocha": "^6.0.0",
     "jsdoc": "^3.5.4",
     "mocha": "^5.0.0",
-    "node-abi": "2.11.0",
     "nyc": "^12.0.2",
     "prebuild": "^9.1.1",
     "semver": "^5.4.1",


### PR DESCRIPTION
#348 added support for Node 13 and Electron v7 so we don't need to pin `node-abi` anymore.

This reverts #345