### PR TITLE
Support for 32bit builds using 64bit node on windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,7 @@
             'action_name': 'build_libzmq',
             'inputs': ['package.json'],
             'outputs': ['libzmq/lib'],
-            'action': ['sh', '<(PRODUCT_DIR)/../../script/build.sh'],
+            'action': ['sh', '<(PRODUCT_DIR)/../../script/build.sh', '<(target_arch)'],
           }],
         }],
       ],

--- a/script/build.sh
+++ b/script/build.sh
@@ -18,7 +18,7 @@ if [ -n "${WINDIR}" ]; then
   # In Travis CI, Node paths are:
   # - C:\ProgramData\nvs\node\<version>\x64\node.exe
   # - C:\ProgramData\nvs\node\<version>\x86\node.exe
-  if [[ "${NODE}" != *"x86"* ]]; then
+  if [[ "${NODE}" != *"x86"* ]] && [[ "$1" != *"ia32"* ]]; then
     # Target Windows x64 platform.
     CMAKE_GENERATOR="${CMAKE_GENERATOR} Win64"
   fi


### PR DESCRIPTION
When trying to build with 64bit node, using the node-gyp `--arch` arg, the rebuilding of `libzmq` ignored it, and it was built as a 64bit lib. 
This PR fixes it.