### PR TITLE
Fix uploading of prebuilds to the GitHub tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,27 +10,38 @@ sudo: required
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: bionic
+      node_js: 12
       env:
         - DEPLOY="true"
         - MAIN="true"
     - os: linux
-      dist: trusty
+      dist: bionic
+      node_js: 12
       env:
         - DEPLOY="true"
         - ARCH="armv7"
     - os: linux
-      dist: trusty
+      dist: bionic
+      node_js: 12
       env:
         - DEPLOY="true"
         - ARCH="armv8"
     - os: linux
-      dist: trusty
-      env:
-        - ELECTRON="3.0.0"
-    - os: osx
+      dist: bionic
+      node_js: 12
       env:
         - DEPLOY="true"
+        - ELECTRON="9.4.4"
+    - os: osx
+      node_js: 12
+      env:
+        - DEPLOY="true"
+    - os: osx
+      node_js: 12
+      env:
+        - DEPLOY="true"
+        - ELECTRON="9.4.4"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ matrix:
         - DEPLOY="true"
         - MAIN="true"
     - os: linux
-      dist: bionic
+      dist: trusty
       node_js: 12
       env:
         - DEPLOY="true"
         - ARCH="armv7"
     - os: linux
-      dist: bionic
+      dist: trusty
       node_js: 12
       env:
         - DEPLOY="true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,11 @@ environment:
   GITHUB_TOKEN:
     secure: E1HpiZf9OJuc8XPGA57hJbCQlMWVCPVBePHiWF/BgmJ/+e/2OplyifiS/x8CJtcw
   matrix:
-    - nodejs_version: "10"
+    - nodejs_version: "12"
       deploy: "true"
-    - nodejs_version: "10"
-      electron: "3.0.0"
+    - nodejs_version: "12"
+      electron: "9.4.4"
+      deploy: "true"
 
 platform:
   - x64


### PR DESCRIPTION
Travis and Appveyor failed to upload the prebuilds to the GitHub tag.
https://github.com/zeromq/zeromq.js/releases/tag/v5.2.1

Previous failures:
https://ci.appveyor.com/project/zeromq/zeromq-js/builds/38706697
https://travis-ci.org/github/zeromq/zeromq.js/builds/767078872