### PR TITLE
Call prepare from node-gyp using actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           architecture: ${{ matrix.node_arch }}
 
       - name: Install Dependencies and Build
-        run: npm run prepare && npm install
+        run: npm install
 
       - name: Prebuildify x64
         if: ${{ contains(matrix.node_arch, 'x64') }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,18 @@
   },
   'targets': [
     {
+      'target_name': 'libzmq',
+      'type': 'none',
+      'actions': [{
+        'action_name': 'prepare-build',
+        'inputs': ['package.json'],
+        'outputs': ['libzmq/lib'],
+        'action': ['node', '<(PRODUCT_DIR)/../../scripts/prepare.js'],
+      }],
+    },
+    {
       'target_name': 'zmq',
+      'dependencies': ['libzmq'],
       'sources': ['binding.cc'],
       'include_dirs' : ["<!(node -e \"require('nan')\")"],
       'cflags!': ['-fno-exceptions'],

--- a/package.json
+++ b/package.json
@@ -25,9 +25,8 @@
     "node": ">=6.0"
   },
   "scripts": {
-    "prepare": "node scripts/prepare.js",
     "install": "node-gyp-build || npm run build:libzmq",
-    "build:libzmq": "npm run prepare && node-gyp rebuild",
+    "build:libzmq": "node-gyp rebuild",
     "prebuildify": "prebuildify -t 15.0.0 -t 14.0.0 -t 12.0.0 -t electron@6.0.0 -t electron@9.4.4 --strip",
     "prebuildify-ia32": "prebuildify --arch=ia32 -t 15.0.0 -t 14.0.0 -t 12.0.0 -t electron@6.0.0 -t electron@9.4.4 --strip",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",


### PR DESCRIPTION
This fixes the fallback when no prebuild is provided