### PR TITLE
Prebuildify only a selection of the versions to reduce size

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "install": "node-gyp-build || npm run build:libzmq",
     "build:libzmq": "node-gyp rebuild",
-    "prebuildify": "prebuildify --all --strip",
-    "prebuildify-ia32": "prebuildify --arch=ia32 --all --strip",
+    "prebuildify": "prebuildify -t 15.7.0 -t 14.16.1 -t 12.4.0 -t electron@5.0.13 -t electron@6.1.12 -t electron@7.3.3 -t electron@8.5.5 -t electron@9.4.4 -t electron@10.4.3 -t electron@11.4.3 --strip",
+    "prebuildify-ia32": "prebuildify --arch=ia32 -t 15.7.0 -t 14.16.1 -t 12.4.0 -t electron@5.0.13 -t electron@6.1.12 -t electron@7.3.3 -t electron@8.5.5 -t electron@9.4.4 -t electron@10.4.3 -t electron@11.4.3  --strip",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
     "test": "mocha --expose-gc --slow 300",
     "test:electron": "electron-mocha --slow 300",


### PR DESCRIPTION
It seems that GitHub Actions is failing to upload the artifacts correctly if the size is larger than some amount. This replaces `prebuildify --all` with a selection of the versions. We had this issue in the previous release, which caused the prebuilds to be faulty.

`prebuildify --all` produced 29 prebuilds for all the versions, but now only 10 of them are selected. For the other versions, the build will happen from the source automatically.


https://github.com/actions/upload-artifact/issues/190