### PR TITLE
Re-add Electron 21 build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -47,6 +47,7 @@
               'xcode_settings': {
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                 'MACOSX_DEPLOYMENT_TARGET': '10.15',
+                'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++17',
               },
               'libraries': ['<(PRODUCT_DIR)/../../zmq/lib/libzmq.a'],
               'include_dirs': ['<(PRODUCT_DIR)/../../zmq/include'],
@@ -56,6 +57,7 @@
             ['OS=="linux"', {
               'libraries': ['<(PRODUCT_DIR)/../../zmq/lib/libzmq.a'],
               'include_dirs': ['<(PRODUCT_DIR)/../../zmq/include'],
+              'cflags_cc': [ '-std=gnu++17' ],
             }],
           ],
         }],

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "install": "node-gyp-build || npm run build:libzmq",
     "build:libzmq": "node-gyp rebuild",
-    "prebuildify": "prebuildify -t 18.12.1 -t 16.18.1 -t 14.21.1 -t 12.22.12 -t electron@11.5.0 --strip",
-    "prebuildify-ia32": "prebuildify --arch=ia32 -t 18.12.1 -t 16.18.1 -t 14.21.1 -t 12.22.12 -t electron@11.5.0 --strip",
+    "prebuildify": "prebuildify -t 18.12.1 -t 16.18.1 -t 14.21.1 -t 12.22.12 -t electron@11.5.0 -t electron@21.0.1 --strip",
+    "prebuildify-ia32": "prebuildify --arch=ia32 -t 18.12.1 -t 16.18.1 -t 14.21.1 -t 12.22.12 -t electron@11.5.0 -t electron@21.0.1 --strip",
     "build:docs": "jsdoc -R README.md -d docs lib/*.js",
     "test": "mocha --expose-gc --slow 300",
     "test:electron": "electron-mocha --slow 300",


### PR DESCRIPTION
This should fix the Electron 21 build for 5.x

Tested on macOS. Untested on Linux, let's leave that up to the CI?