### PR TITLE
Fix: Detect Electron version at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test/typings-compatibility/
 /script/*/*.js.map
 tsconfig.tsbuildinfo
 /docs-raw
+.DS_Store

--- a/src/incoming_msg.cc
+++ b/src/incoming_msg.cc
@@ -15,7 +15,8 @@ IncomingMsg::~IncomingMsg() {
 }
 
 Napi::Value IncomingMsg::IntoBuffer(const Napi::Env& env) {
-    if (!hasElectronMemoryCage(env)) {
+    static auto const noElectronMemoryCage = !hasElectronMemoryCage(env);
+    if (noElectronMemoryCage) {
         if (moved) {
             /* If ownership has been transferred, do not attempt to read the buffer
                again in any case. This should not happen of course. */
@@ -26,7 +27,7 @@ Napi::Value IncomingMsg::IntoBuffer(const Napi::Env& env) {
     auto data = reinterpret_cast<uint8_t*>(zmq_msg_data(*ref));
     auto length = zmq_msg_size(*ref);
 
-    if (!hasElectronMemoryCage(env)) {
+    if (noElectronMemoryCage) {
         static auto constexpr zero_copy_threshold = 1 << 7;
         if (length > zero_copy_threshold) {
             /* Reuse existing buffer for external storage. This avoids copying but

--- a/src/util/electron_helper.h
+++ b/src/util/electron_helper.h
@@ -27,8 +27,6 @@ static inline bool hasElectronMemoryCage(const Napi::Env& env) {
     if (!hasRun) {
         if (IsElectron(env)) {
             auto electronVers = env.Global()
-                                    .Get("window")
-                                    .ToObject()
                                     .Get("process")
                                     .ToObject()
                                     .Get("versions")

--- a/src/util/electron_helper.h
+++ b/src/util/electron_helper.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <napi.h>
+#include <string>
+
+namespace zmq {
+bool hasRun = false;
+bool hasElectronMemoryCageCache = false;
+
+static inline std::string first_component(std::string const& value) {
+    std::string::size_type pos = value.find('.');
+    return pos == value.npos ? value : value.substr(0, pos);
+}
+
+/* Check if runtime is Electron. */
+static inline bool IsElectron(const Napi::Env& env) {
+    auto global = env.Global();
+    auto isElectron = global.Get("process")
+                          .As<Napi::Object>()
+                          .Get("versions")
+                          .As<Napi::Object>()
+                          .Has("electron");
+    return isElectron;
+}
+
+static inline bool hasElectronMemoryCage(const Napi::Env& env) {
+    if (!hasRun) {
+        if (IsElectron(env)) {
+            auto electronVers = env.Global()
+                                    .Get("window")
+                                    .ToObject()
+                                    .Get("process")
+                                    .ToObject()
+                                    .Get("versions")
+                                    .ToObject()
+                                    .Get("electron")
+                                    .ToString()
+                                    .Utf8Value();
+            int majorVer = stoi(first_component(electronVers));
+            if (majorVer >= 21) {
+                hasElectronMemoryCageCache = true;
+            }
+        }
+        hasRun = true;
+    }
+    return hasElectronMemoryCageCache;
+}
+}


### PR DESCRIPTION
This way, no separate build for NodeJS and Electron v21(+) is needed.
Cache the result once, to not have to look up the value on each incoming message.