### PR TITLE
Update README example for pub/sub message logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ sock.subscribe('kitty cats');
 console.log('Subscriber connected to port 3000');
 
 sock.on('message', function(topic, message) {
-  console.log('received a message related to:', topic, 'containing message:', message);
+  console.log('received a message related to:', topic.toString(), 'containing message:', message.toString());
 });
 ```
 


### PR DESCRIPTION
Following the example from the docs, with 5.x I get buffers:

```
received a message related to: <Buffer 6b 69 74 74 79 20 63 61 74 73> containing message: <Buffer 6d 65 6f 77 21>
```

Which need to be cast to strings with .toString() to produce what I assume is the intended output:

```
received a message related to: kitty cats containing message: meow!
```

