### PR TITLE
Fix linking of libsodium for linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -76,6 +76,7 @@
             ['OS != "win"', {
               'libraries': [
                 '<(module_root_dir)/build/libzmq/lib/libzmq.a',
+                "<!@(pkg-config libsodium --libs)",
               ],
             }],
 


### PR DESCRIPTION
Bumped into this issue myself when trying to build it on a Docket Debian 9 machine (circleci/node:gallium-stretch-browsers) with:

```
circleci@38f5f51a4027:~/git/klstr-ctrl$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
VERSION_CODENAME=stretch
ID=debian
```

```
circleci@38f5f51a4027:~/git/klstr-ctrl$ gcc --version
gcc (Debian 8.3.0-6) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
circleci@38f5f51a4027:~/git/klstr-ctrl$ cmake --version
cmake version 3.16.3

CMake suite maintained and supported by Kitware (kitware.com/cmake)
```

```
-- Detected ZMQ Version - 4.3.5
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29") 
```


```
-- Checking for module 'libsodium'
--   Found libsodium, version 1.0.17
-- Found sodium: /usr/lib/x86_64-linux-gnu/libsodium.so  
```


Compiling works fine, but when trying to run/require the `.node` module, I got the following error:

```
node: symbol lookup error: node_modules/zeromq/build/Release/zeromq.node: undefined symbol: sodium_init
```

I also found a bug report on stackoverflow by coincidence:
https://stackoverflow.com/questions/74796706/node-application-doesnt-start-with-zeromq-node-undefined-symbol-sodium-init

Apparently, as found in this post on stackoverflow: https://stackoverflow.com/questions/57740825/use-libsodium-in-napi
, bindings.gyp also need the libsodium `libraries` dependency in order to link properly.


I did not change anything for Windows. As I suspect everything works okay there.
I guess it's also `OS`/`gcc`/`cmake` related. As on my other VM build machine (Ubuntu 20.04 / gcc 9.4.0 / cmake 3.16.3), I didn't have linker problems.
I switched to an older build system as my findings of incompatible GLIBC versions, as described here: https://github.com/zeromq/zeromq.js/issues/529#issuecomment-1368825640