### PR TITLE
Fix: Remove libsodium dependency (for now).

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -82,7 +82,6 @@
             ['OS == "mac"', {
               'libraries': [
                 '<(module_root_dir)/build/libzmq/lib/libzmq.a',
-                "<!@(pkg-config libsodium --libs)",
               ],
             }],
 

--- a/script/build.ts
+++ b/script/build.ts
@@ -78,7 +78,7 @@ function main() {
     writeFileSync(clang_format_file, "")
   }
 
-  const cmake_configure = `cmake -S "${src_dir}" -B ./build ${build_options} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX="${libzmq_install_prefix}" -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_STATIC=ON -DBUILD_TESTS=OFF -DBUILD_SHARED=OFF -DWITH_DOCS=OFF -DWITH_LIBSODIUM=ON -DWITH_LIBSODIUM_STATIC=ON`
+  const cmake_configure = `cmake -S "${src_dir}" -B ./build ${build_options} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX="${libzmq_install_prefix}" -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_STATIC=ON -DBUILD_TESTS=OFF -DBUILD_SHARED=OFF -DWITH_DOCS=OFF -DWITH_LIBSODIUM=OFF`
   console.log(cmake_configure)
   exec(cmake_configure, execOptions)
 


### PR DESCRIPTION
Use TweetNacl, which doesn't need a (user having) libsodium installed.


As discussed here: https://github.com/zeromq/zeromq.js/issues/529#issuecomment-1370721089 , libzmq doesn't handle statically linking `libsodium`.

I think the best, and most versatile option (keeping in mind all build platforms: Unix, Alpine, macOS x64, macOS ARM, Windows x64, Windows ARM, ...), as a next step, to build libsodium ourselves in the build.ts, before `libzmq` itself. Preferably with `libsodium-cmake` (https://github.com/robinlinden/libsodium-cmake) .