### PR TITLE
fix: update libzmq to the latest version

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -7,7 +7,7 @@ const root = dirname(__dirname)
 function main() {
   const zmq_rev =
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/strict-boolean-expressions
-    process.env.ZMQ_VERSION || "20de92ac0a2b2b9a1869782a429df68f93c3625e"
+    process.env.ZMQ_VERSION || "5657b4586f24ec433930e8ece02ddba7afcf0fe0"
   const src_url = `https://github.com/zeromq/libzmq/archive/${zmq_rev}.tar.gz`
 
   const libzmq_build_prefix = `${root}/build/libzmq-staging`


### PR DESCRIPTION
This fixes the build with newer platforms and compilers. It also includes other fixes from libzmq