### PR TITLE
docs: Fix link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Useful links
 
-* [ZeroMQ.js API reference](http://zeromq.github.io/zeromq.js/globals.html).
+* [ZeroMQ.js API reference](http://zeromq.github.io/zeromq.js/modules.html).
 * [ZeroMQ project documentation](https://zeromq.org/get-started/).
   * **Note:** The Node.js examples on zeromq.org do not yet reflect the new API, but [the Guide](http://zguide.zeromq.org) in particular is still a good introduction to ZeroMQ for new users.
 


### PR DESCRIPTION
Previously, this link in the readme was giving me a 404 not found