### PR TITLE
Remove cross-compilation arch flags for MacOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -134,12 +134,6 @@
                 ],
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                 'GCC_ENABLE_EXCEPTIONS': 'YES',
-                'OTHER_CFLAGS': [
-                  "<!(echo \"-arch ${ARCH:=x86_64}\")",
-                ],
-                'OTHER_LDFLAGS': [
-                  "<!(echo \"-arch ${ARCH:=x86_64}\")",
-                ]
               },
             }],
 
@@ -227,12 +221,6 @@
                 'DEAD_CODE_STRIPPING': 'YES',
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                 'GCC_ENABLE_EXCEPTIONS': 'YES',
-                'OTHER_CFLAGS': [
-                  "<!(echo \"-arch ${ARCH:=x86_64}\")",
-                ],
-                'OTHER_LDFLAGS': [
-                  "<!(echo \"-arch ${ARCH:=x86_64}\")",
-                ]
               },
             }],
 


### PR DESCRIPTION
~`CMAKE_OSX_ARCHITECTURES` is already set in `build.js`, so there's no need to set it in `binding.gyp`.~ In fact, if the architecture is inferred from the host (and not via the `$ARCH` env var), this previously resulted in incorrect cross-compiling.

Fixes #632 