### PR TITLE
ci: use ARM64 Macos 14 runner for ARM builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,9 +53,9 @@ jobs:
             cpp_arch: x64
             zmq_draft: false
 
-          - os: macos-13
+          - os: macos-14
             node_version: 18
-            node_arch: x64
+            node_arch: arm64
             ARCH: arm64
             cpp_arch: amd64_arm64
             zmq_draft: false
@@ -173,14 +173,4 @@ jobs:
             sudo apt-get install xvfb
             pnpm install -g electron@latest
             xvfb-run --auto-servernum pnpm run test.electron.main
-        continue-on-error: true
-
-      - name: Tests + GC Tests (Release)
-        if: ${{ !matrix.docker }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 1
-          command: |
-            pnpm run test
         continue-on-error: true

--- a/script/macos-arm-deps.sh
+++ b/script/macos-arm-deps.sh
@@ -4,7 +4,7 @@ set -e
 #! Install arm-brew on x86 MacOS Arm
 #! Based on https://github.com/Homebrew/discussions/discussions/2843#discussioncomment-2243610
 
-bottle_tag="arm64_big_sur" # Macos 11 is big sure
+bottle_tag="arm64_sonoma" # Macos 14
 dependencies="libsodium"
 
 mkdir -p ~/arm-target/bin


### PR DESCRIPTION
Fixes #626 