### PR TITLE
fix: reduce production build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,8 @@
   "homepage": "http://zeromq.github.io/zeromq.js/",
   "dependencies": {
     "@aminya/node-gyp-build": "4.8.1-aminya.1",
-    "cross-env": "^7.0.3",
     "node-addon-api": "^7.1.0",
-    "shelljs": "^0.8.5",
-    "shx": "^0.3.4"
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
     "@types/chai": "^4.3.16",
@@ -56,7 +54,9 @@
     "ts-node": "~10.9.2",
     "typedoc": "^0.25.13",
     "typescript": "~4.9.5",
-    "which": "^4.0.0"
+    "which": "^4.0.0",
+    "cross-env": "^7.0.3",
+    "shx": "^0.3.4"
   },
   "pnpm": {
     "overrides": {
@@ -82,7 +82,7 @@
     "tsconfig.json"
   ],
   "scripts": {
-    "install": "(shx test -f ./script/build.js || run-s build.js) && cross-env npm_config_build_from_source=true aminya-node-gyp-build",
+    "install": "(npm run build.js || echo ok) && aminya-node-gyp-build --build-from-source",
     "clean": "shx rm -rf ./build ./lib/ ./prebuilds ./script/*.js ./script/*.js.map ./script/*.d.ts ./script/*.tsbuildinfo",
     "clean.release": "shx rm -rf ./build/Release",
     "clean.temp": "shx rm -rf ./tmp && shx mkdir -p ./tmp",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,18 +15,12 @@ importers:
       '@aminya/node-gyp-build':
         specifier: 4.8.1-aminya.1
         version: 4.8.1-aminya.1
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
       node-addon-api:
         specifier: ^7.1.0
         version: 7.1.0
       shelljs:
         specifier: ^0.8.5
         version: 0.8.5
-      shx:
-        specifier: ^0.3.4
-        version: 0.3.4
     devDependencies:
       '@types/chai':
         specifier: ^4.3.16
@@ -58,6 +52,9 @@ importers:
       chai:
         specifier: ^4.4.1
         version: 4.4.1
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       deasync:
         specifier: ^0.1.30
         version: 0.1.30
@@ -109,6 +106,9 @@ importers:
       semver:
         specifier: ^7.6.2
         version: 7.6.2
+      shx:
+        specifier: ^0.3.4
+        version: 0.3.4
       ts-node:
         specifier: ~10.9.2
         version: 10.9.2(@types/node@20.14.3)(typescript@4.9.5)


### PR DESCRIPTION
The install script runs on the user machine, and at that point, the JavaScript files are already included in the package