### PR TITLE
Use pkg-config for including shared libzmq

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -64,7 +64,12 @@
 
         ["zmq_shared == 'true'", {
           'link_settings': {
-            'libraries': ['-lzmq'],
+            'ldflags': [
+              '<!(pkg-config --libs-only-other --libs-only-L libzmq)'
+            ],
+            'libraries': [
+              '<!(pkg-config --libs-only-l libzmq)'
+            ],
           },
         }, {
           'conditions': [


### PR DESCRIPTION
Currently on FreeBSD (tried only on 14.1) fails with shared libzmq:

```
$> rm -rf node_modules/
$> npm install
$> npm run build --zmq-shared

[…]
Building libzmq with options  {
  zmq_shared: true,
  […]
}
[…]
ld: error: unable to find library -lzmq
c++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake: *** [zeromq.target.mk:154: Release/obj.target/zeromq.node] Error 1
[…]
```

The problem is that linking with `-lzmq` is not sufficient on FreeBSD, it requires `-L/usr/local/lib -lzmq`. Using pkg-config might help.

After applying this patch, it builds.

On FreeBSD 14.1:

```
$> pkg-config --libs libzmq
-L/usr/local/lib -lzmq
```

On Linux:

```
$> pkg-config --libs libzmq
-lzmq
```

---

Might help #639 by allowing to use shared libzmq.