### PR TITLE
fix: specify build_from_source using env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "tsconfig.json"
   ],
   "scripts": {
-    "install": "(npm run build.js || echo ok) && aminya-node-gyp-build --build-from-source",
+    "install": "(npm run build.js || echo ok) && cross-env npm_config_build_from_source=true aminya-node-gyp-build",
     "clean": "shx rm -rf ./build ./lib/ ./prebuilds ./script/*.js ./script/*.mjs ./script/*.js.map ./script/*.mjs.map ./script/*.d.ts ./script/*.d.mts ./script/*.cjs ./scripts/*.cjs.map ./scripts/*.d.cts ./script/*.tsbuildinfo",
     "clean.release": "shx rm -rf ./build/Release",
     "clean.temp": "shx rm -rf ./tmp && shx mkdir -p ./tmp",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,7 @@
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "types": [
-      "node",
-      "mocha"
-    ],
+    "forceConsistentCasingInFileNames": true,
     "strictPropertyInitialization": false, // TODO
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Newer npm/yarn versions don't populate `process.env.npm_config_argv` resulting in `npm/yarn` installs hanging. This fixes the issue

https://github.com/prebuild/node-gyp-build/blob/464e3881600de2107f35fd1c55afff232a768123/bin.js#L75

Fixes #644
Fixes #647 
Fixes #646