### PR TITLE
Typescript cannot find types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "typesVersions": {
     ">=3.7": {
       "lib/*": [
-        "lib/ts3.7/*"
+        "lib/*"
       ]
     }
   },


### PR DESCRIPTION
Hey,

The `typesVersions` field of the repo `package.json` reference a folder that does not exist and thus typescript is not able to resolve types correctly.

My commit simply removed the folder, I don't know if `typesVersions` is still necessary.

Best.