### PR TITLE
feat: enable Draft support in the prebuild binaries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
             cpp_arch: x64
 
     env:
-      npm_config_zmq_draft: false
+      npm_config_zmq_draft: true
       npm_config_zmq_shared: false
       npm_config_arch: ${{ matrix.node_arch }}
       npm_config_target_arch: ${{ matrix.node_arch }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
         cpp_arch:
           - x64
     env:
-      npm_config_zmq_draft: false
+      npm_config_zmq_draft: true
       npm_config_zmq_shared: false
       npm_config_arch: ${{ matrix.node_arch }}
       npm_config_target_arch: ${{ matrix.node_arch }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   'variables': {
     'zmq_shared%': 'false',
-    'zmq_draft%': 'false',
+    'zmq_draft%': 'true',
     'zmq_no_sync_resolve%': 'false',
     'sanitizers%': 'false',
     'openssl_fips': '',

--- a/script/build.js
+++ b/script/build.js
@@ -8,7 +8,7 @@ const root = (0, path_1.dirname)(__dirname);
 function parseOptions() {
     return {
         zmq_shared: (0, utils_js_1.toBool)(process.env.npm_config_zmq_shared) ?? false,
-        zmq_draft: (0, utils_js_1.toBool)(process.env.npm_config_zmq_draft) ?? false,
+        zmq_draft: (0, utils_js_1.toBool)(process.env.npm_config_zmq_draft) ?? true,
         zmq_version: (0, utils_js_1.toString)(process.env.npm_config_zmq_version) ??
             "5657b4586f24ec433930e8ece02ddba7afcf0fe0",
         zmq_build_type: (0, utils_js_1.toString)(process.env.npm_config_zmq_build_type) ?? "Release",

--- a/script/build.ts
+++ b/script/build.ts
@@ -17,7 +17,7 @@ type Options = {
 function parseOptions(): Options {
   return {
     zmq_shared: toBool(process.env.npm_config_zmq_shared) ?? false,
-    zmq_draft: toBool(process.env.npm_config_zmq_draft) ?? false,
+    zmq_draft: toBool(process.env.npm_config_zmq_draft) ?? true,
     zmq_version:
       toString(process.env.npm_config_zmq_version) ??
       "5657b4586f24ec433930e8ece02ddba7afcf0fe0",


### PR DESCRIPTION
Fixes #638 

This requires the installation of gnutls. We should link it statically to avoid needing the dependency during runtime.