### PR TITLE
fix: add missing include for chrono on Windows

### DIFF
--- a/src/module.h
+++ b/src/module.h
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 #include <future>
+#include <chrono>
 
 #include "./closable.h"
 #include "./outgoing_msg.h"


### PR DESCRIPTION
The new MSVC headers don't expose the chrono_literals unless chrono is included. 